### PR TITLE
Add SCP send functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ let status = try session.execute("ls -a")
 let (status, output) = try session.capture("pwd")
 ```
 
+### Send files
+
+You can send a local file to a remote path, similar to the `scp` command line program, with `sendFile`.
+```swift
+let status = try session.sendFile(localURL: myLocalFile, remotePath: "~/cats.png")
+```
+
 ### Configuration
 
 You can instruct the session to request a pty (pseudo terminal) before executing commands:

--- a/Sources/Shout/FilePermissions.swift
+++ b/Sources/Shout/FilePermissions.swift
@@ -1,0 +1,65 @@
+//
+//  FilePermissions.swift
+//  Shout
+//
+//  Created by Brandon Evans on 1/25/19.
+//
+
+import Foundation
+import CSSH
+
+public struct Permissions : OptionSet {
+    public let rawValue: UInt
+    public init(rawValue: UInt) {
+        self.rawValue = rawValue
+    }
+    
+    public static let read = Permissions(rawValue: 1 << 1)
+    public static let write = Permissions(rawValue: 1 << 2)
+    public static let execute = Permissions(rawValue: 1 << 3)
+}
+
+public struct FilePermissions {
+    public var owner: Permissions
+    public var group: Permissions
+    public var others: Permissions
+
+    public init(owner: Permissions, group: Permissions, others: Permissions) {
+        self.owner = owner
+        self.group = group
+        self.others = others
+    }
+    
+    public static func fromPosixPermissions(_ value: CShort) -> FilePermissions {
+        var permissions = FilePermissions(owner: [], group: [], others: [])
+        if (value & CShort(S_IRUSR) == CShort(S_IRUSR)) { permissions.owner.insert(.read) }
+        if (value & CShort(S_IWUSR) == CShort(S_IWUSR)) { permissions.owner.insert(.write) }
+        if (value & CShort(S_IXUSR) == CShort(S_IXUSR)) { permissions.owner.insert(.execute) }
+        if (value & CShort(S_IRGRP) == CShort(S_IRGRP)) { permissions.group.insert(.read) }
+        if (value & CShort(S_IWGRP) == CShort(S_IWGRP)) { permissions.group.insert(.write) }
+        if (value & CShort(S_IXGRP) == CShort(S_IXGRP)) { permissions.group.insert(.execute) }
+        if (value & CShort(S_IROTH) == CShort(S_IROTH)) { permissions.others.insert(.read) }
+        if (value & CShort(S_IWOTH) == CShort(S_IWOTH)) { permissions.others.insert(.write) }
+        if (value & CShort(S_IXOTH) == CShort(S_IXOTH)) { permissions.others.insert(.execute) }
+        return permissions
+    }
+    
+    public static let defaultPermissions = FilePermissions(owner: [.read, .write], group: [.read], others: [.read])
+
+    public static func libsshPermissionFlag(_ permissions: FilePermissions) -> Int32 {
+        var flag: Int32 = 0
+        if permissions.owner.contains(.read) { flag |= LIBSSH2_SFTP_S_IRUSR }
+        if permissions.owner.contains(.write) { flag |= LIBSSH2_SFTP_S_IWUSR }
+        if permissions.owner.contains(.execute) { flag |= LIBSSH2_SFTP_S_IXUSR }
+        
+        if permissions.group.contains(.read) { flag |= LIBSSH2_SFTP_S_IRGRP }
+        if permissions.group.contains(.write) { flag |= LIBSSH2_SFTP_S_IWGRP }
+        if permissions.group.contains(.execute) { flag |= LIBSSH2_SFTP_S_IXGRP }
+        
+        if permissions.others.contains(.read) { flag |= LIBSSH2_SFTP_S_IROTH }
+        if permissions.others.contains(.write) { flag |= LIBSSH2_SFTP_S_IWOTH }
+        if permissions.others.contains(.execute) { flag |= LIBSSH2_SFTP_S_IXOTH }
+        
+        return flag
+    }
+}

--- a/Sources/Shout/SCPChannel.swift
+++ b/Sources/Shout/SCPChannel.swift
@@ -1,0 +1,66 @@
+//
+//  SCPChannel.swift
+//  Shout
+//
+//  Created by Brandon Evans on 1/19/19.
+//
+
+import Foundation
+import CSSH
+
+public class SCPChannel {
+
+    private let cSession: OpaquePointer
+    private let cChannel: OpaquePointer
+    private let localURL: URL
+    private let remotePath: String
+
+    public init(cSession: OpaquePointer, localURL: URL, remotePath: String, permissions: FilePermissions = .default) throws {
+        guard
+            let resources = try? localURL.resourceValues(forKeys: [.fileSizeKey]),
+            let fileSize = resources.fileSize,
+            let cChannel = libssh2_scp_send64(cSession, remotePath, permissions.rawValue, Int64(fileSize), 0, 0)
+        else { throw LibSSH2Error(code: -1, session: cSession) }
+
+        self.cSession = cSession
+        self.cChannel = cChannel
+        self.localURL = localURL
+        self.remotePath = remotePath
+    }
+
+    public func sendFile() throws {
+        guard let inputStream = InputStream(url: localURL) else { return }
+        inputStream.open()
+        defer { inputStream.close() }
+
+        let bufferSize = 32768
+        var buffer = Data(capacity: bufferSize)
+        let streamID: Int32 = 0
+
+        while inputStream.hasBytesAvailable {
+            let bytesRead = buffer.withUnsafeMutableBytes { data in
+                inputStream.read(data, maxLength: bufferSize)
+            }
+            if bytesRead == 0 { break }
+
+            let bytesWritten = buffer.withUnsafeBytes { data in
+                libssh2_channel_write_ex(cChannel, streamID, data, bytesRead)
+            }
+            try LibSSH2Error.checkOnRead(code: Int32(bytesWritten), session: cSession)
+        }
+
+        libssh2_channel_send_eof(cChannel)
+        libssh2_channel_wait_eof(cChannel)
+        libssh2_channel_close(cChannel)
+        libssh2_channel_wait_closed(cChannel)
+    }
+
+    public func exitStatus() -> Int32 {
+        return libssh2_channel_get_exit_status(cChannel)
+    }
+
+    deinit {
+        libssh2_channel_free(cChannel)
+    }
+
+}

--- a/Sources/Shout/SFTP.swift
+++ b/Sources/Shout/SFTP.swift
@@ -11,45 +11,6 @@ import CSSH
 public class SFTP {
     private let sftpSession: OpaquePointer
     
-    public struct Permissions : OptionSet {
-        public let rawValue: UInt
-        public init(rawValue: UInt) {
-            self.rawValue = rawValue
-        }
-        
-        public static let read = Permissions(rawValue: 1 << 1)
-        public static let write = Permissions(rawValue: 1 << 2)
-        public static let execute = Permissions(rawValue: 1 << 3)
-    }
-    
-    public struct FilePermissions {
-        public var owner: Permissions
-        public var group: Permissions
-        public var others: Permissions
-
-        public init(owner: Permissions, group: Permissions, others: Permissions) {
-            self.owner = owner
-            self.group = group
-            self.others = others
-        }
-        
-        public static func fromPosixPermissions(_ value: CShort) -> FilePermissions {
-            var permissions = FilePermissions(owner: [], group: [], others: [])
-            if (value & CShort(S_IRUSR) == CShort(S_IRUSR)) { permissions.owner.insert(.read) }
-            if (value & CShort(S_IWUSR) == CShort(S_IWUSR)) { permissions.owner.insert(.write) }
-            if (value & CShort(S_IXUSR) == CShort(S_IXUSR)) { permissions.owner.insert(.execute) }
-            if (value & CShort(S_IRGRP) == CShort(S_IRGRP)) { permissions.group.insert(.read) }
-            if (value & CShort(S_IWGRP) == CShort(S_IWGRP)) { permissions.group.insert(.write) }
-            if (value & CShort(S_IXGRP) == CShort(S_IXGRP)) { permissions.group.insert(.execute) }
-            if (value & CShort(S_IROTH) == CShort(S_IROTH)) { permissions.others.insert(.read) }
-            if (value & CShort(S_IWOTH) == CShort(S_IWOTH)) { permissions.others.insert(.write) }
-            if (value & CShort(S_IXOTH) == CShort(S_IXOTH)) { permissions.others.insert(.execute) }
-            return permissions
-        }
-        
-        public static let defaultPermissions = FilePermissions(owner: [.read, .write], group: [.read], others: [.read])
-    }
-    
     public init(cSession: OpaquePointer) throws {
         guard let sftpSession = libssh2_sftp_init(cSession) else {
             throw LibSSH2Error(code: -1, message: "libssh2_sftp_init failed")
@@ -67,7 +28,7 @@ public class SFTP {
             remotePath,
             UInt32(remotePath.count),
             UInt(LIBSSH2_FXF_WRITE | LIBSSH2_FXF_CREAT),
-            Int(LIBSSH2_SFTP_S_IFREG | libsshPermissionFlag(permissions)),
+            Int(LIBSSH2_SFTP_S_IFREG | FilePermissions.libsshPermissionFlag(permissions)),
             LIBSSH2_SFTP_OPENFILE) else
         {
             throw LibSSH2Error(code: -1, message: "libssh2_sftp_open_ex failed")
@@ -97,20 +58,4 @@ public class SFTP {
         libssh2_sftp_close_handle(sftpHandle)
     }
     
-    private func libsshPermissionFlag(_ permissions: FilePermissions) -> Int32 {
-        var flag: Int32 = 0
-        if permissions.owner.contains(.read) { flag |= LIBSSH2_SFTP_S_IRUSR }
-        if permissions.owner.contains(.write) { flag |= LIBSSH2_SFTP_S_IWUSR }
-        if permissions.owner.contains(.execute) { flag |= LIBSSH2_SFTP_S_IXUSR }
-        
-        if permissions.group.contains(.read) { flag |= LIBSSH2_SFTP_S_IRGRP }
-        if permissions.group.contains(.write) { flag |= LIBSSH2_SFTP_S_IWGRP }
-        if permissions.group.contains(.execute) { flag |= LIBSSH2_SFTP_S_IXGRP }
-        
-        if permissions.others.contains(.read) { flag |= LIBSSH2_SFTP_S_IROTH }
-        if permissions.others.contains(.write) { flag |= LIBSSH2_SFTP_S_IWOTH }
-        if permissions.others.contains(.execute) { flag |= LIBSSH2_SFTP_S_IXOTH }
-        
-        return flag
-    }
 }

--- a/Sources/Shout/SFTP.swift
+++ b/Sources/Shout/SFTP.swift
@@ -22,13 +22,13 @@ public class SFTP {
         libssh2_sftp_shutdown(sftpSession)
     }
     
-    public func upload(localUrl: URL, remotePath: String, permissions: FilePermissions = FilePermissions.defaultPermissions) throws {
+    public func upload(localUrl: URL, remotePath: String, permissions: FilePermissions = .default) throws {
         guard let sftpHandle = libssh2_sftp_open_ex(
             sftpSession,
             remotePath,
             UInt32(remotePath.count),
             UInt(LIBSSH2_FXF_WRITE | LIBSSH2_FXF_CREAT),
-            Int(LIBSSH2_SFTP_S_IFREG | FilePermissions.libsshPermissionFlag(permissions)),
+            Int(LIBSSH2_SFTP_S_IFREG | permissions.rawValue),
             LIBSSH2_SFTP_OPENFILE) else
         {
             throw LibSSH2Error(code: -1, message: "libssh2_sftp_open_ex failed")

--- a/Sources/Shout/SSH.swift
+++ b/Sources/Shout/SSH.swift
@@ -112,6 +112,12 @@ public class SSH {
     public func openSftp() throws -> SFTP {
         return try session.openSftp()
     }
+
+    public func sendFile(localURL: URL, remotePath: String, permissions: FilePermissions = .default) throws -> Int32 {
+        let channel = try session.openSCPChannel(localURL: localURL, remotePath: remotePath, permissions: permissions)
+        try channel.sendFile()
+        return channel.exitStatus()
+    }
 }
 
 // MARK: - Deprecations

--- a/Sources/Shout/Session.swift
+++ b/Sources/Shout/Session.swift
@@ -5,6 +5,7 @@
 //  Created by Jake Heiser on 3/4/18.
 //
 
+import Foundation
 import CSSH
 import Socket
 
@@ -65,6 +66,10 @@ class Session {
     
     func openChannel() throws -> Channel {
         return try Channel(cSession: cSession)
+    }
+
+    public func openSCPChannel(localURL: URL, remotePath: String, permissions: FilePermissions = .default) throws -> SCPChannel {
+        return try SCPChannel(cSession: cSession, localURL: localURL, remotePath: remotePath, permissions: permissions)
     }
     
     func agent() throws -> Agent {

--- a/Tests/ShoutTests/ShoutTests.swift
+++ b/Tests/ShoutTests/ShoutTests.swift
@@ -43,10 +43,20 @@ class ShoutTests: XCTestCase {
         }
     }
 
+    func testSendFile() throws {
+        try SSH.connect(host: "jakeheis.com", username: "", authMethod: SSHAgent()) { (ssh) in
+            try ssh.sendFile(localURL: URL(fileURLWithPath: String(#file)), remotePath: "/tmp/upload_test.swift", permissions: FilePermissions.default)
+            print(try ssh.capture("cat /tmp/upload_test.swift"))
+            print(try ssh.capture("ls -l /tmp/upload_test.swift"))
+            print(try ssh.capture("rm /tmp/upload_test.swift"))
+        }
+    }
+
     static var allTests = [
         ("testCapture", testCapture),
         ("testConnect", testConnect),
         ("testUpload", testUpload),
+        ("testSendFile", testSendFile),
     ]
 
 }


### PR DESCRIPTION
This adds the ability to send files to the remote with libSSH2's SCP functionality.

This should merge after #15, because I'd like to make use of the new Permissions and FilePermissions types that were added there instead of making users worry about octal literals. Once it merges I'll update this PR to do that.

I'm not confident in the changes to the tests that I made. They don't do anything locally, but I'm assuming that Travis is configured so that they run correctly.