### PR TITLE
Consolidate Swift package targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,8 +13,7 @@ let package = Package(
         .package(url: "https://github.com/jakeheis/CSSH", from: "1.0.3"),
     ],
     targets: [
-        .target(name: "Bindings", dependencies: ["Socket"]),
-        .target(name: "Shout", dependencies: ["Bindings", "Socket"]),
+        .target(name: "Shout", dependencies: ["Socket"]),
         .testTarget(name: "ShoutTests", dependencies: ["Shout"]),
     ]
 )

--- a/Sources/Shout/Agent.swift
+++ b/Sources/Shout/Agent.swift
@@ -1,19 +1,19 @@
 //
 //  Agent.swift
-//  Bindings
+//  Shout
 //
 //  Created by Jake Heiser on 3/4/18.
 //
 
 import CSSH
 
-public class Agent {
+class Agent {
     
-    public class PublicKey: CustomStringConvertible {
+    class PublicKey: CustomStringConvertible {
         
         fileprivate let cIdentity: UnsafeMutablePointer<libssh2_agent_publickey>
         
-        public var description: String {
+        var description: String {
             return "Public key: " + String(cString: cIdentity.pointee.comment)
         }
         
@@ -34,17 +34,17 @@ public class Agent {
         self.cAgent = cAgent
     }
     
-    public func connect() throws {
+    func connect() throws {
         let code = libssh2_agent_connect(cAgent)
         try LibSSH2Error.check(code: code, session: cSession)
     }
     
-    public func listIdentities() throws {
+    func listIdentities() throws {
         let code = libssh2_agent_list_identities(cAgent)
         try LibSSH2Error.check(code: code, session: cSession)
     }
     
-    public func getIdentity(last: PublicKey?) throws -> PublicKey? {
+    func getIdentity(last: PublicKey?) throws -> PublicKey? {
         var publicKeyOptional: UnsafeMutablePointer<libssh2_agent_publickey>? = nil
         let code = libssh2_agent_get_identity(cAgent, UnsafeMutablePointer(mutating: &publicKeyOptional), last?.cIdentity)
         
@@ -61,7 +61,7 @@ public class Agent {
         return PublicKey(cIdentity: publicKey)
     }
     
-    public func authenticate(username: String, key: PublicKey) -> Bool {
+    func authenticate(username: String, key: PublicKey) -> Bool {
         let code = libssh2_agent_userauth(cAgent, username, key.cIdentity)
         return code == 0
     }

--- a/Sources/Shout/Channel.swift
+++ b/Sources/Shout/Channel.swift
@@ -1,6 +1,6 @@
 //
 //  Channel.swift
-//  Bindings
+//  Shout
 //
 //  Created by Jake Heiser on 3/4/18.
 //
@@ -8,7 +8,7 @@
 import CSSH
 import struct Foundation.Data
 
-public class Channel {
+class Channel {
     
     private static let session = "session"
     private static let exec = "exec"
@@ -32,7 +32,7 @@ public class Channel {
         self.cChannel = cChannel
     }
     
-    public func requestPty(type: String) throws {
+    func requestPty(type: String) throws {
         let code = libssh2_channel_request_pty_ex(cChannel,
                                                   type, UInt32(type.utf8.count),
                                                   nil, 0,
@@ -41,7 +41,7 @@ public class Channel {
         try LibSSH2Error.check(code: code, session: cSession)
     }
     
-    public func exec(command: String) throws {
+    func exec(command: String) throws {
         let code = libssh2_channel_process_startup(cChannel,
                                                    Channel.exec,
                                                    UInt32(Channel.exec.count),
@@ -50,7 +50,7 @@ public class Channel {
         try LibSSH2Error.check(code: code, session: cSession)
     }
     
-    public func readData() throws -> (data: Data, bytes: Int) {
+    func readData() throws -> (data: Data, bytes: Int) {
         var data = Data(repeating: 0, count: Channel.bufferSize)
         
         let rc: Int = data.withUnsafeMutableBytes { (buffer: UnsafeMutablePointer<Int8>) in
@@ -62,17 +62,17 @@ public class Channel {
         return (data, rc)
     }
     
-    public func close() throws {
+    func close() throws {
         let code = libssh2_channel_close(cChannel)
         try LibSSH2Error.check(code: code, session: cSession)
     }
     
-    public func waitClosed() throws {
+    func waitClosed() throws {
         let code2 = libssh2_channel_wait_closed(cChannel)
         try LibSSH2Error.check(code: code2, session: cSession)
     }
     
-    public func exitStatus() -> Int32 {
+    func exitStatus() -> Int32 {
         return libssh2_channel_get_exit_status(cChannel)
     }
     

--- a/Sources/Shout/Code.swift
+++ b/Sources/Shout/Code.swift
@@ -1,6 +1,6 @@
 //
 //  Code.swift
-//  Bindings
+//  Shout
 //
 //  Created by Jake Heiser on 3/6/18.
 //

--- a/Sources/Shout/Error.swift
+++ b/Sources/Shout/Error.swift
@@ -1,6 +1,6 @@
 //
 //  Error.swift
-//  Bindings
+//  Shout
 //
 //  Created by Jake Heiser on 3/4/18.
 //
@@ -9,37 +9,37 @@ import CSSH
 
 public struct LibSSH2Error: Swift.Error {
     
-    public static func checkOnRead(code: Int32, session: OpaquePointer) throws {
+    static func checkOnRead(code: Int32, session: OpaquePointer) throws {
         if code < 0 {
             throw LibSSH2Error(code: code, session: session)
         }
     }
     
-    public static func check(code: Int32, session: OpaquePointer) throws {
+    static func check(code: Int32, session: OpaquePointer) throws {
         if code != 0 {
             throw LibSSH2Error(code: code, session: session)
         }
     }
     
-    public static func check(code: Int32, message: String) throws {
+    static func check(code: Int32, message: String) throws {
         if code != 0 {
             throw LibSSH2Error(code: code, message: message)
         }
     }
     
-    public let rawCode: Int32
-    public let message: String
+    let rawCode: Int32
+    let message: String
     
-    public var code: Code? {
+    var code: Code? {
         return Code(rawValue: -rawCode)
     }
     
-    public init(code: Int32, message: String) {
+    init(code: Int32, message: String) {
         self.rawCode = code
         self.message = message
     }
     
-    public init(code: Int32, session: OpaquePointer) {
+    init(code: Int32, session: OpaquePointer) {
         var messagePointer: UnsafeMutablePointer<Int8>? = nil
         var length: Int32 = 0
         libssh2_session_last_error(session, &messagePointer, &length, 0)

--- a/Sources/Shout/SFTP.swift
+++ b/Sources/Shout/SFTP.swift
@@ -1,6 +1,6 @@
 //
 //  SFTP.swift
-//  Bindings
+//  Shout
 //
 //  Created by Vladislav Alexeev on 6/20/18.
 //

--- a/Sources/Shout/SSH.swift
+++ b/Sources/Shout/SSH.swift
@@ -5,7 +5,6 @@
 //  Created by Jake Heiser on 3/4/18.
 //
 
-import Bindings
 import Foundation
 import Socket
 
@@ -28,12 +27,12 @@ public class SSH {
     
     public var ptyType: PtyType? = nil
     let sock: Socket
-    let session: Bindings.Session
+    let session: Shout.Session
     
     public init(host: String, port: Int32 = 22) throws {
         do {
             self.sock = try Socket.create()
-            self.session = try Bindings.Session()
+            self.session = try Shout.Session()
             
             session.blocking = 1
             try sock.connect(to: host, port: port)

--- a/Sources/Shout/SSHAuthMethod.swift
+++ b/Sources/Shout/SSHAuthMethod.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Bindings
 
 public protocol SSHAuthMethod {
     func authenticate(ssh: SSH, username: String) throws
@@ -35,7 +34,7 @@ public struct SSHAgent: SSHAuthMethod {
         try agent.connect()
         try agent.listIdentities()
         
-        var last: Bindings.Agent.PublicKey? = nil
+        var last: Agent.PublicKey? = nil
         var success: Bool = false
         while let identity = try agent.getIdentity(last: last) {
             if agent.authenticate(username: username, key: identity) {

--- a/Sources/Shout/SSHError.swift
+++ b/Sources/Shout/SSHError.swift
@@ -5,8 +5,6 @@
 //  Created by Jake Heiser on 3/6/18.
 //
 
-import Bindings
-
 public struct SSHError: Swift.Error, CustomStringConvertible {
     
     private let libError: LibSSH2Error

--- a/Sources/Shout/Session.swift
+++ b/Sources/Shout/Session.swift
@@ -1,6 +1,6 @@
 //
 //  Session.swift
-//  Bindings
+//  Shout
 //
 //  Created by Jake Heiser on 3/4/18.
 //
@@ -8,14 +8,14 @@
 import CSSH
 import Socket
 
-public class Session {
+class Session {
     
     private static let initResult = libssh2_init(0)
     
     private let cSession: OpaquePointer
     private var _agent: Agent?
     
-    public var blocking: Int32 {
+    var blocking: Int32 {
         get {
             return libssh2_session_get_blocking(cSession)
         }
@@ -24,7 +24,7 @@ public class Session {
         }
     }
     
-    public init() throws {
+    init() throws {
         try LibSSH2Error.check(code: Session.initResult, message: "libssh2_init failed")
         
         guard let cSession = libssh2_session_init_ex(nil, nil, nil, nil) else {
@@ -34,12 +34,12 @@ public class Session {
         self.cSession = cSession
     }
     
-    public func handshake(over socket: Socket) throws {
+    func handshake(over socket: Socket) throws {
         let code = libssh2_session_handshake(cSession, socket.socketfd)
         try LibSSH2Error.check(code: code, session: cSession)
     }
     
-    public func authenticate(username: String, privateKey: String, publicKey: String, passphrase: String?) throws {
+    func authenticate(username: String, privateKey: String, publicKey: String, passphrase: String?) throws {
         let code = libssh2_userauth_publickey_fromfile_ex(cSession,
                                                           username,
                                                           UInt32(username.count),
@@ -49,7 +49,7 @@ public class Session {
         try LibSSH2Error.check(code: code, session: cSession)
     }
     
-    public func authenticate(username: String, password: String) throws {
+    func authenticate(username: String, password: String) throws {
         let code = libssh2_userauth_password_ex(cSession,
                                                 username,
                                                 UInt32(username.count),
@@ -59,15 +59,15 @@ public class Session {
         try LibSSH2Error.check(code: code, session: cSession)
     }
     
-    public func openSftp() throws -> SFTP  {
+    func openSftp() throws -> SFTP  {
         return try SFTP(cSession: cSession)
     }
     
-    public func openChannel() throws -> Channel {
+    func openChannel() throws -> Channel {
         return try Channel(cSession: cSession)
     }
     
-    public func agent() throws -> Agent {
+    func agent() throws -> Agent {
         if let agent = _agent {
             return agent
         }

--- a/Tests/ShoutTests/ShoutTests.swift
+++ b/Tests/ShoutTests/ShoutTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable import Shout
+import Shout
 
 class ShoutTests: XCTestCase {
     


### PR DESCRIPTION
As [mentioned](https://github.com/jakeheis/Shout/pull/18#issuecomment-456649081) in #18, right now there is some difficulty in using types that are in the Bindings target or that should be public but used in both targets. I figured I should try to contribute my proposed change, so this PR consolidates the two targets into one. The types in Bindings were made internal, except for SFTP and any types that had to be public because they were used by Shout's public types. I also removed the `@testable` annotation from the test file in order to make sure that the public API was being tested correctly.