### PR TITLE
Enabling public access for new SFTP methods

### DIFF
--- a/Sources/Shout/SFTP.swift
+++ b/Sources/Shout/SFTP.swift
@@ -166,7 +166,7 @@ public class SFTP {
     /// - Parameters:
     ///   - remotePath: the path for the folder, which should be created
     /// - Throws: SSHError if folder can't be created
-    func createDirectory(_ path: String) throws {
+    public func createDirectory(_ path: String) throws {
         let result = path.withCString { (pointer: UnsafePointer<Int8>) -> Int32 in
             return libssh2_sftp_mkdir_ex(sftpSession, pointer, UInt32(strlen(pointer)), Int(LIBSSH2_SFTP_S_IRWXU | LIBSSH2_SFTP_S_IRGRP | LIBSSH2_SFTP_S_IXGRP | LIBSSH2_SFTP_S_IROTH | LIBSSH2_SFTP_S_IXOTH))
         }
@@ -180,7 +180,7 @@ public class SFTP {
     ///   - dest: the new path of the file
     ///   - override: set to true, if rename should override if there is already a file on dest path
     /// - Throws: SSHError if file can't be renamed
-    func rename(src: String, dest: String, override: Bool) throws {
+    public func rename(src: String, dest: String, override: Bool) throws {
         var flag: Int = Int(LIBSSH2_SFTP_RENAME_OVERWRITE)
         if !override { flag = 0 }
         
@@ -197,7 +197,7 @@ public class SFTP {
     /// - Parameters:
     ///   - remotePath: the path of the file, which should be removed
     /// - Throws: SSHError if file can't be deleted
-    func removeFile(_ path: String) throws {
+    public func removeFile(_ path: String) throws {
         let result = path.withCString { (pointer: UnsafePointer<Int8>) -> Int32 in
             return libssh2_sftp_unlink_ex(sftpSession, pointer, UInt32(strlen(pointer)))
         }
@@ -209,7 +209,7 @@ public class SFTP {
     /// - Parameters:
     ///   - remotePath: the path of the folder, which should be removed
     /// - Throws: SSHError if folder can't be deleted
-    func removeDirectory(_ path: String) throws {
+    public func removeDirectory(_ path: String) throws {
         let result = path.withCString { (pointer: UnsafePointer<Int8>) -> Int32 in
             return libssh2_sftp_rmdir_ex(sftpSession, pointer, UInt32(strlen(pointer)))
         }

--- a/Tests/ShoutTests/SFTPTests.swift
+++ b/Tests/ShoutTests/SFTPTests.swift
@@ -44,5 +44,81 @@ class SFTPTests: XCTestCase {
             XCTAssertEqual(try ssh.execute("rm /tmp/shout_upload_test.swift", silent: false), 0)
         }
     }
+    
+    func testCreateDirectory() throws {
+        try SSH.connect(host: ShoutServer.host, username: ShoutServer.username, authMethod: ShoutServer.authMethod) { (ssh) in
+            let sftp = try ssh.openSftp()
+            
+            try sftp.createDirectory("/tmp/shout_folder_test")
+            
+            let (status, contents) = try ssh.capture("if test -d /tmp/shout_folder_test; then echo \"exists\"; fi")
+            XCTAssertEqual(status, 0)
+            XCTAssertEqual(contents.components(separatedBy: "\n")[0], "exists")
+            
+            XCTAssertEqual(try ssh.execute("rm -rf /tmp/shout_folder_test", silent: false), 0)
+        }
+    }
+    
+    func testRemoveDirectory() throws {
+        try SSH.connect(host: ShoutServer.host, username: ShoutServer.username, authMethod: ShoutServer.authMethod) { (ssh) in
+            let sftp = try ssh.openSftp()
+            
+            // First create directory
+            try sftp.createDirectory("/tmp/shout_folder_test")
+            let (statusC, contentsC) = try ssh.capture("if test -d /tmp/shout_folder_test; then echo \"exists\"; fi")
+            XCTAssertEqual(statusC, 0)
+            XCTAssertEqual(contentsC.components(separatedBy: "\n")[0], "exists")
+            
+            // Then delete
+            try sftp.removeDirectory("/tmp/shout_folder_test")
+            
+            let (statusR, contentsR) = try ssh.capture("if test ! -d /tmp/shout_remove_test; then echo \"removed\"; fi")
+            XCTAssertEqual(statusR, 0)
+            XCTAssertEqual(contentsR.components(separatedBy: "\n")[0], "removed")
+        }
+    }
+    
+    func testRename() throws {
+        try SSH.connect(host: ShoutServer.host, username: ShoutServer.username, authMethod: ShoutServer.authMethod) { (ssh) in
+            let sftp = try ssh.openSftp()
+            
+            // Create dummy file
+            let (statusC, _) = try ssh.capture("touch /tmp/shout_rename_test1")
+            XCTAssertEqual(statusC, 0)
+            
+            // Then rename
+            try sftp.rename(src: "/tmp/shout_rename_test1", dest: "/tmp/shout_rename_test2", override: true)
+            
+            // Check if old file is gone
+            let (statusO, contentsO) = try ssh.capture("if test ! -f /tmp/shout_remove_test; then echo \"gone\"; fi")
+            XCTAssertEqual(statusO, 0)
+            XCTAssertEqual(contentsO.components(separatedBy: "\n")[0], "gone")
+            
+            // Check if new file is there
+            let (statusN, contentsN) = try ssh.capture("if test -f /tmp/shout_rename_test2; then echo \"exists\"; fi")
+            XCTAssertEqual(statusN, 0)
+            XCTAssertEqual(contentsN.components(separatedBy: "\n")[0], "exists")
+            
+            XCTAssertEqual(try ssh.execute("rm /tmp/shout_rename_test2", silent: false), 0)
+        }
+    }
+    
+    func testRemove() throws {
+        try SSH.connect(host: ShoutServer.host, username: ShoutServer.username, authMethod: ShoutServer.authMethod) { (ssh) in
+            let sftp = try ssh.openSftp()
+            
+            // Create dummy file
+            let (statusC, _) = try ssh.capture("touch /tmp/shout_remove_test")
+            XCTAssertEqual(statusC, 0)
+            
+            // Remove file
+            try sftp.removeFile("/tmp/shout_remove_test")
+            
+            // Check if old file is gone
+            let (statusR, contentsR) = try ssh.capture("if test ! -f /tmp/shout_remove_test; then echo \"removed\"; fi")
+            XCTAssertEqual(statusR, 0)
+            XCTAssertEqual(contentsR.components(separatedBy: "\n")[0], "removed")
+        }
+    }
 
 }

--- a/Tests/ShoutTests/XCTestManifests.swift
+++ b/Tests/ShoutTests/XCTestManifests.swift
@@ -4,6 +4,10 @@ extension SFTPTests {
     static let __allTests = [
         ("testDownload", testDownload),
         ("testUpload", testUpload),
+        ("testRemove", testRemove),
+        ("testRename", testRename),
+        ("testRemoveDirectory", testRemoveDirectory),
+        ("testCreateDirectory", testCreateDirectory)
     ]
 }
 


### PR DESCRIPTION
The newly added SFTP methods from #38 we're not accessible from the outside. Added `public` identifier to the methods, that we're missing it.
Also added tests for new SFTP methods from #38  