### PR TITLE
Fixes unicode support

### DIFF
--- a/Sources/Shout/Channel.swift
+++ b/Sources/Shout/Channel.swift
@@ -60,7 +60,7 @@ class Channel {
                                                    Channel.exec,
                                                    UInt32(Channel.exec.count),
                                                    command,
-                                                   UInt32(command.count))
+                                                   UInt32(command.utf8.count))
         try SSHError.check(code: code, session: cSession)
     }
     

--- a/Sources/Shout/SFTP.swift
+++ b/Sources/Shout/SFTP.swift
@@ -26,7 +26,7 @@ public class SFTP {
             guard let sftpHandle = libssh2_sftp_open_ex(
                 sftpSession,
                 remotePath,
-                UInt32(remotePath.count),
+                UInt32(remotePath.utf8.count),
                 UInt(flags),
                 Int(mode),
                 openType) else {

--- a/Sources/Shout/Session.swift
+++ b/Sources/Shout/Session.swift
@@ -46,7 +46,7 @@ class Session {
     func authenticate(username: String, privateKey: String, publicKey: String, passphrase: String?) throws {
         let code = libssh2_userauth_publickey_fromfile_ex(cSession,
                                                           username,
-                                                          UInt32(username.count),
+                                                          UInt32(username.utf8.count),
                                                           publicKey,
                                                           privateKey,
                                                           passphrase)
@@ -56,9 +56,9 @@ class Session {
     func authenticate(username: String, password: String) throws {
         let code = libssh2_userauth_password_ex(cSession,
                                                 username,
-                                                UInt32(username.count),
+                                                UInt32(username.utf8.count),
                                                 password,
-                                                UInt32(password.count),
+                                                UInt32(password.utf8.count),
                                                 nil)
         try SSHError.check(code: code, session: cSession)
     }

--- a/Tests/ShoutTests/SSHTests.swift
+++ b/Tests/ShoutTests/SSHTests.swift
@@ -49,4 +49,13 @@ class ShoutTests: XCTestCase {
         }
     }
 
+    func testUnicode() throws {
+        try SSH.connect(host: ShoutServer.host, username: ShoutServer.username, authMethod: ShoutServer.authMethod) { (ssh) in
+            let (status, _) = try ssh.capture("touch /tmp/你好")
+            XCTAssertEqual(status, 0)
+
+            XCTAssertEqual(try ssh.execute("rm /tmp/你好", silent: false), 0)
+        }
+    }
+
 }


### PR DESCRIPTION
Some libssh methods that take a char pointer and char count need to use `String.utf8.count` instead of `String.count`, else the parameter will be malformed.

```swift
  1> "你好".count
$R0: Int = 2
  2> "你好".utf8.count
$R1: Int = 6
```